### PR TITLE
#149 add additional text after artists as optional field

### DIFF
--- a/apps/cms/schemas/documents/general-settings.js
+++ b/apps/cms/schemas/documents/general-settings.js
@@ -6,6 +6,7 @@ const fields = [
     title: "Titel der Website",
     name: "websiteTitle",
     type: "string",
+    description: "wird im Browser Tab angezeigt",
   },
   {
     ...getImage(false),
@@ -18,6 +19,12 @@ const fields = [
     title: "Banner Mobile",
     name: "bannerMobile",
     description: "1800px breit und 2250px hoch sein für optimale Darstellung",
+  },
+  {
+    name: "additionalTextAfterArtists",
+    type: "string",
+    title: "Text nach Künstler Liste",
+    description: 'zum Beispiel "und viele mehr"',
   },
 ];
 

--- a/apps/website/lib/general-settings.ts
+++ b/apps/website/lib/general-settings.ts
@@ -24,6 +24,7 @@ export interface IGeneralSettings {
     height: number;
   };
   showNewsAsPrimaryContent: boolean;
+  additionalTextAfterArtists: string;
 }
 
 export const getGeneralSettings = async (
@@ -36,7 +37,9 @@ export const getGeneralSettings = async (
     'bannerDesktopEn': languages.en.bannerDesktop,
     'bannerMobileDe': languages.de.bannerMobile,
     'bannerMobileEn': languages.en.bannerMobile,
-    'displayMode': displayMode
+    'displayMode': displayMode,
+    'additionalTextAfterArtistsDe': languages.de.additionalTextAfterArtists,
+    'additionalTextAfterArtistsEn': languages.en.additionalTextAfterArtists,
   }`;
   const result = (await client.fetch(query))[0];
   const bannerDesktop =
@@ -91,5 +94,10 @@ export const getGeneralSettings = async (
     showNewsAsPrimaryContent: result.displayMode
       ? result.displayMode === "news"
       : true,
+    additionalTextAfterArtists:
+      locale === "de"
+        ? result.additionalTextAfterArtistsDe
+        : result.additionalTextAfterArtistsEn ??
+          result.additionalTextAfterArtistsDe,
   };
 };

--- a/apps/website/pages/index.tsx
+++ b/apps/website/pages/index.tsx
@@ -167,6 +167,9 @@ export default function Home(props: HomeProps): JSX.Element {
                   {index === array.length - 1 ? "" : "•"}
                 </span>
               ))}
+            {props.generalSettings.additionalTextAfterArtists && (
+              <span> • {props.generalSettings.additionalTextAfterArtists}</span>
+            )}
           </>
         )}
         {props.generalSettings.showNewsAsPrimaryContent && (


### PR DESCRIPTION
closes #149

Neues Textfeld unter Allgemein hinzugefügt:
<img width="807" alt="image" src="https://user-images.githubusercontent.com/34143718/229060814-c08fdafe-7efc-4cdd-9da4-3e2ac020efee.png">

Wenn gesetzt, wird hinter der Artist Liste dieser Text angezeigt
<img width="997" alt="image" src="https://user-images.githubusercontent.com/34143718/229060956-c6a13afd-2239-4e7a-bb15-29808214af7d.png">
