### PR TITLE
docs: rewrite CLAUDE.md with accurate monorepo conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@
 ## Structure
 - `apps/website` — Next.js 15 SSG, **Pages Router** (not App Router), TypeScript strict, Tailwind
 - `apps/cms` — Sanity Studio 4, headless CMS
-- Path alias: `@/*` → `./src/*` in website
+- Website app structure uses top-level folders such as `components`, `lib`, and `pages` (no documented `src/` alias)
 
 ## Conventions
 - TypeScript strict mode everywhere — no `any`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@
 - Website app structure uses top-level folders such as `components`, `lib`, and `pages` (no documented `src/` alias)
 
 ## Conventions
-- TypeScript strict mode everywhere — no `any`
+- TypeScript strict mode everywhere — avoid `any` when possible, and document exception cases
 - i18n via `next-intl`; locales `de` (default) and `en`
 - No `.env` files committed — secrets (`MAILJET_*`, `SANITY_STUDIO_*`) fetched via Doppler at session start into `.env.local`
 - Deployed on Vercel

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,5 +18,5 @@
 ## Conventions
 - TypeScript strict mode everywhere — no `any`
 - i18n via `next-intl`; locales `de` (default) and `en`
-- Environment variables are not committed — pull via `vercel env pull`
+- No `.env` files committed — required vars are `MAILJET_*` and `SANITY_STUDIO_*` (ask user)
 - Deployed on Vercel

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,5 +18,5 @@
 ## Conventions
 - TypeScript strict mode everywhere — no `any`
 - i18n via `next-intl`; locales `de` (default) and `en`
-- No `.env` files committed — required vars are `MAILJET_*` and `SANITY_STUDIO_*` (ask user)
+- No `.env` files committed — secrets (`MAILJET_*`, `SANITY_STUDIO_*`) fetched via Doppler at session start into `.env.local`
 - Deployed on Vercel

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,18 +1,22 @@
 # Immergutrocken Monorepo
 
-## Stack
-- pnpm + Turborepo monorepo
-- apps/website, apps/cms
-- TypeScript strict mode throughout
-- Deployed on Vercel
+## Package Manager
+- Always use `pnpm` — never npm or yarn
 
 ## Commands
-- Build: `turbo run build`
+- Install: `pnpm install`
+- Dev: `turbo run dev`
+- Build: `turbo run build` — run after every change to verify compilation
 - Test: `turbo run test`
 - Lint: `turbo run lint`
-- Install: `pnpm install`
 
-## Rules
-- Never use npm or yarn, always pnpm
-- Run `turbo run build` after any change to verify compilation
-- TypeScript strict mode, no `any`
+## Structure
+- `apps/website` — Next.js 15 SSG, **Pages Router** (not App Router), TypeScript strict, Tailwind
+- `apps/cms` — Sanity Studio 4, headless CMS
+- Path alias: `@/*` → `./src/*` in website
+
+## Conventions
+- TypeScript strict mode everywhere — no `any`
+- i18n via `next-intl`; locales `de` (default) and `en`
+- Environment variables are not committed — pull via `vercel env pull`
+- Deployed on Vercel

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,3 +20,4 @@
 - i18n via `next-intl`; locales `de` (default) and `en`
 - No `.env` files committed — secrets (`MAILJET_*`, `SANITY_STUDIO_*`) fetched via Doppler at session start into `.env.local`
 - Deployed on Vercel
+- If you discover a convention or constraint not listed here, add it to this file and commit it


### PR DESCRIPTION
Adds Pages Router clarification, i18n defaults, path alias, Sanity CMS, and env var workflow — details that would cause mistakes if omitted.

https://claude.ai/code/session_01AXqtp74iinsWR7vMUxkxLK