### PR TITLE
Add Gemini Code Assist config and document code review tooling

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,15 @@
+reviews:
+  instructions: |
+    Before reviewing, read CLAUDE.md in the repository root to understand
+    the project conventions. Key points:
+    - Package manager is pnpm — flag any npm or yarn usage
+    - apps/website is Next.js 15 SSG using Pages Router (not App Router) with TypeScript strict and Tailwind
+    - apps/cms is Sanity Studio 4
+    - TypeScript strict mode everywhere — avoid `any`, document exceptions
+    - i18n via next-intl with locales `de` (default) and `en`
+    - No .env files committed — secrets via Doppler into .env.local
+  path_instructions:
+    - path: "apps/website/**"
+      instructions: "Pages Router only — flag any App Router patterns (e.g. app/ directory, server components, use client without Pages Router context)."
+    - path: "apps/cms/**"
+      instructions: "Sanity Studio 4 — flag deprecated Sanity v3 APIs or patterns."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,5 +23,5 @@
 - If you discover a convention or constraint not listed here, add it to this file and commit it
 
 ## Code Review
-- PRs are reviewed automatically by **CodeRabbit** (free tier, GitHub App)
-- CodeRabbit is configured via `.coderabbit.yaml` in the repo root — update that file when conventions here change
+- PRs are reviewed automatically by **Gemini Code Assist** (free, GitHub App)
+- Gemini is configured via `gemini-code-assist.yaml` in the repo root — update that file when conventions here change

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,3 +21,7 @@
 - No `.env` files committed — secrets (`MAILJET_*`, `SANITY_STUDIO_*`) fetched via Doppler at session start into `.env.local`
 - Deployed on Vercel
 - If you discover a convention or constraint not listed here, add it to this file and commit it
+
+## Code Review
+- PRs are reviewed automatically by **CodeRabbit** (free tier, GitHub App)
+- CodeRabbit is configured via `.coderabbit.yaml` in the repo root — update that file when conventions here change

--- a/gemini-code-assist.yaml
+++ b/gemini-code-assist.yaml
@@ -1,4 +1,5 @@
-reviews:
+code_review:
+  comment_severity_threshold: MEDIUM
   instructions: |
     Before reviewing, read CLAUDE.md in the repository root to understand
     the project conventions. Key points:
@@ -9,7 +10,7 @@ reviews:
     - i18n via next-intl with locales `de` (default) and `en`
     - No .env files committed — secrets via Doppler into .env.local
   path_instructions:
-    - path: "apps/website/**"
+    - glob: "apps/website/**"
       instructions: "Pages Router only — flag any App Router patterns (e.g. app/ directory, server components, use client without Pages Router context)."
-    - path: "apps/cms/**"
+    - glob: "apps/cms/**"
       instructions: "Sanity Studio 4 — flag deprecated Sanity v3 APIs or patterns."


### PR DESCRIPTION
## Summary

- Adds `gemini-code-assist.yaml` with custom review instructions derived from `CLAUDE.md` conventions (pnpm, Pages Router only, TypeScript strict, next-intl i18n, Sanity Studio 4)
- Updates `CLAUDE.md` to document that Gemini Code Assist is the AI code reviewer and that `gemini-code-assist.yaml` should be kept in sync when conventions change

## Next steps

- Gemini Code Assist GitHub App is already installed on the repository
- Gemini will automatically review new PRs using the config in `gemini-code-assist.yaml`

## Test plan

- [ ] Verify Gemini Code Assist posts review comments on this PR
- [ ] Confirm comments reflect the configured conventions (Pages Router, pnpm, strict TS, etc.)

https://claude.ai/code/session_01CCk562adWpnxYxYXQ5SDv7