### PR TITLE
Document e2e testing conventions in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 - Dev: `turbo run dev`
 - Build: `turbo run build` — run after every change to verify compilation
 - Test: `turbo run test`
-- E2E: `pnpm run test:e2e` (also runs in CI, see `.github/workflows/e2e-tests.yml`)
+- E2E: `turbo run test:e2e` (also runs in CI, see `.github/workflows/e2e-tests.yml`)
 - Lint: `turbo run lint`
 
 ## Structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,13 @@
 - Dev: `turbo run dev`
 - Build: `turbo run build` — run after every change to verify compilation
 - Test: `turbo run test`
+- E2E: `pnpm run test:e2e` (also runs in CI, see `.github/workflows/e2e-tests.yml`)
 - Lint: `turbo run lint`
 
 ## Structure
 - `apps/website` — Next.js 15 SSG, **Pages Router** (not App Router), TypeScript strict, Tailwind
 - `apps/cms` — Sanity Studio 4, headless CMS
+- `packages/e2e` — Playwright e2e tests spanning both apps; lives outside `apps/*` for that reason
 - Website app structure uses top-level folders such as `components`, `lib`, and `pages` (no documented `src/` alias)
 
 ## Conventions
@@ -20,7 +22,15 @@
 - i18n via `next-intl`; locales `de` (default) and `en`
 - No `.env` files committed — secrets (`MAILJET_*`, `SANITY_STUDIO_*`) fetched via Doppler at session start into `.env.local`
 - Deployed on Vercel
+- `turbo.json` tasks run in strict env mode: any `process.env.*` a task's script reads must be listed in that task's `env` array in `turbo.json`, or turbo strips it from the subprocess (only OS defaults like `PATH`/`HOME` pass through automatically) — e.g. `CI` had to be added explicitly for Playwright's CI-aware config to see it
+- GitHub Actions workflows need an explicit `permissions:` block (CodeQL flags workflows that don't limit `GITHUB_TOKEN` scope) — `contents: read` is enough unless a step needs more
 - If you discover a convention or constraint not listed here, add it to this file and commit it
+
+## E2E testing (`packages/e2e`)
+- WebKit only (most visitors are on Safari/iOS), against a dedicated public/read-only Sanity dataset `e2e-test` (project `05hvmwlk`) — not a secret, hardcoded in `playwright.config.ts` and CI, no `.env` needed
+- Runs the site under test via `next dev`, not `next build && next start` — a production build statically exports *every* page, which would require `e2e-test` to have fixture data for the whole site; dev mode only renders the page actually requested
+- The **Sanity MCP tools have no binary asset upload** — only document CRUD. Anything needing a real image (e.g. the artist page's required banner) has to be seeded/edited manually in Sanity Studio; MCP can only handle the non-image singleton docs (`menu`, `sortings`) a page's `getStaticProps` chain depends on
+- Locator preference: role/text/alt/href over `data-testid` — the site's existing semantic markup (headings, `next/image` alt text, link hrefs) already gives unique, meaningful selectors without editing `apps/website` source just for testability
 
 ## Code Review
 - PRs are reviewed automatically by **Gemini Code Assist** (free, GitHub App)


### PR DESCRIPTION
## Summary

Follow-up to #551/#552 — capturing what came up while building the first e2e Playwright PoC, per this repo's own `CLAUDE.md` convention ("If you discover a convention or constraint not listed here, add it to this file and commit it").

Added to `CLAUDE.md`:
- `packages/e2e` location/purpose, and the `pnpm run test:e2e` command
- Why the e2e webServer uses `next dev` instead of `next build && next start` (avoids needing fixture data for the entire site)
- The Sanity MCP tools have no binary asset upload — only document CRUD — so anything needing a real image has to be seeded manually in Sanity Studio
- Locator preference (role/text/alt/href over `data-testid`) and why
- Turbo's strict env mode: a task's script can only see `process.env.*` vars explicitly listed in that task's `env` array in `turbo.json`
- GitHub Actions workflows need an explicit `permissions:` block (CodeQL enforces this)

No code changes — documentation only.

## Test plan

- [x] Reviewed the diff for accuracy against what actually happened in #551/#552

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Jy2fgE3rCCJGq4vnBHLQqP)_