### PR TITLE
Document the PR workflow: Claude flips the draft to ready

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,3 +48,8 @@
 - Greptile indexes `CLAUDE.md` automatically, so conventions documented here already feed into reviews — `greptile.json` only carries the review-behaviour settings plus per-path rules (`customContext.rules` with glob `scope`s). Keep the rules in sync when conventions here change; don't duplicate this file wholesale into it
 - Credit budget shapes the config: `triggerOnUpdates` is `false`, so a PR costs one credit when it's opened instead of one per push, and `excludeAuthors` skips `renovate[bot]` so dependency PRs don't eat the month
 - Account settings (AI training opt-out, plan, App installation) live in the Greptile web UI — there is no MCP server or API path for them
+
+## PR workflow
+- The goal is that a human only reviews once everything that can run automatically has run. So the draft state means "CI still running or work unfinished", not "waiting for a human to press a button"
+- Claude opens PRs as drafts, then **marks them ready for review itself** once CI is green and it is satisfied with the change — that is also what triggers the Greptile review (`triggerOnDrafts` is `false`), so it lands on the finished state instead of the first push. Exception: if the change involves a decision Claude is genuinely unsure about, leave it as a draft and ask instead of flipping it
+- Whatever Greptile then reports, Claude addresses on the same branch; the follow-up pushes cost no extra credit (`triggerOnUpdates` is `false`). Merging stays a human decision


### PR DESCRIPTION
Follow-up to #557. Records the PR workflow we just agreed on as a convention in `CLAUDE.md`, so it survives into future sessions.

## What changed

A new "PR workflow" section in `CLAUDE.md` stating:

- The goal: a human reviews only once everything automatable has run. The draft state therefore means *"CI still running or work unfinished"*, not *"waiting for a human to press a button"*.
- Claude opens PRs as drafts and **marks them ready for review itself** once CI is green — which is also what triggers the Greptile review (`triggerOnDrafts: false`), so the credit lands on the finished state rather than the first push. Exception: if the change hinges on a decision Claude is genuinely unsure about, it stays a draft and Claude asks.
- Greptile's findings get addressed on the same branch at no extra credit (`triggerOnUpdates: false`). Merging stays a human decision.

## Note

This PR is itself the first run of that workflow: it's open as a draft now, and I'll flip it to ready once the checks come back green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WV7CTrZgapLKtCwaZz5gFF

---
_Generated by [Claude Code](https://claude.ai/code/session_01WV7CTrZgapLKtCwaZz5gFF)_

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Documentation-only PR that records the agreed PR workflow convention in `CLAUDE.md`. No code is changed.

- Adds a new `## PR workflow` section explaining that the draft state signals \"CI still running or work unfinished\", not \"waiting for a human\", and that Claude is responsible for flipping the PR to ready once CI is green.
- Documents how Greptile credit is conserved: the flip to ready is what triggers the review (`triggerOnDrafts: false`), and follow-up fixes on the same branch cost nothing (`triggerOnUpdates: false`); merging remains a human decision.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — purely adds documentation with no code changes.

The change is three bullet points in CLAUDE.md that accurately describe the workflow already in use. The wording is consistent with the existing Greptile configuration notes already in the file, and nothing in the repository's code, tests, or CI config is touched.

**Files Needing Attention:** No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| CLAUDE.md | Adds a "PR workflow" section documenting the draft→ready convention; consistent with the existing Greptile config notes already in the file. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Document the PR workflow: Claude flips t..."](https://github.com/immergutrocken/immergutrocken/commit/9dd4a1e60906e9ac29e98dcbbf5f619c9e12ff38) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49615513)</sub>

<!-- /greptile_comment -->